### PR TITLE
Hashtag shouldn't start with a '#'

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -5,7 +5,9 @@ class Topic < ApplicationRecord
   include PgSearch::Model
 
   belongs_to :user
+
   validates :title, :hashtag, :x_link, presence: true
+  validates :hashtag, format: { without: /\A#/, message: I18n.t('topics.validations.hashtag') }
 
   friendly_id :title, use: :slugged
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,4 +28,6 @@
 #       enabled: "ON"
 
 en:
-  hello: "Hello world"
+  topics:
+    validations:
+      hashtag: "should not start with '#' "

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Topic do
   it { is_expected.to validate_presence_of :x_link }
   it { is_expected.to validate_presence_of :hashtag }
   it { is_expected.to belong_to :user }
+  it { is_expected.not_to allow_value('#hashtag').for(:hashtag) }
 end
 
 # == Schema Information


### PR DESCRIPTION
## Summary of changes
Add model validation for hashtag
## How to test changes
Attempt to create a new topic with a ''#' in the hashtag field
## Issue id
Closes #21 
## Screenshot(s)
![hashtag](https://github.com/dngst/trendingonx/assets/94643104/2e97cd16-4285-483d-bd58-4cbd3802b29c)

